### PR TITLE
Corrected example of Galway address.

### DIFF
--- a/testcases/countries/ie.yaml
+++ b/testcases/countries/ie.yaml
@@ -10,4 +10,4 @@ components:
     road: Mainguard Street
     state_district: Connacht
     suburb: Claddagh
-expected: 8-9 Mainguard Street, Galway City, Connacht, Ireland
+expected: 8-9 Mainguard Street, Galway, Ireland


### PR DESCRIPTION
The example for Ireland is wrong. This is a more accurate answer. I'm not sure how to run the tests, so I wasn't able to fix the code, merely fix the test ;).

Irish addresses are pretty freaking weird. :)
