### PR TITLE
Removing extra tokens from Turkish addresses

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -581,15 +581,7 @@ TN:
 
 # Turkey
 TR: 
-    address_template: |
-        {{{attention}}}
-        {{{house}}}
-        {{{road}}}
-        Maçka No:{{{house_number}}} 
-        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{state}}} {{/first}} 
-        {{{country}}}
-    replace:
-        - [" Caddesi"," Cad."]
+    address_template: *generic1
 
 # Trinidad and Tobago
 TT:

--- a/testcases/countries/tr.yaml
+++ b/testcases/countries/tr.yaml
@@ -11,4 +11,4 @@ components:
     state: Istanbul
     suburb: Vişnezade
     town: Beşiktaş
-expected: Swissotel Bosphorus, Bayıldım Cad., Maçka No:2, 34357 Beşiktaş, Turkey
+expected: Swissotel Bosphorus, Bayıldım Cad. 2, 34357 Beşiktaş, Turkey

--- a/testcases/countries/tr.yaml
+++ b/testcases/countries/tr.yaml
@@ -11,4 +11,4 @@ components:
     state: Istanbul
     suburb: Vişnezade
     town: Beşiktaş
-expected: Swissotel Bosphorus, Bayıldım Cad. 2, 34357 Beşiktaş, Turkey
+expected: Swissotel Bosphorus, Bayıldım Caddesi 2, 34357 Beşiktaş, Turkey


### PR DESCRIPTION
Hey Ed,

Another issue that came up in my parser is appending the tokens "Maçka No:" before Turkish house numbers.

It looks like Maçka is either a city in Turkey or a neighborhood in Istanbul and not present in every address.

Using "No:" before the house number looks to be very common in written addresses, but I think maybe this can be done in a field-level preprocessing step instead of the address formatting template. In some address data sets for instance the street field may already be "No:2" in which case the formatter would rewrite it to "No:No:2". It may also be written "No." or "Numara". Incidentally [libpostal](https://github.com/openvenues/libpostal), the address NLP library I'm working on, recognizes all of those forms as well as Cad/Caddesi, and many other street-level abbreviations in 50+ languages. Though we currently rewrite using the canonical longer forms, it may be worth looking at after the official release.

In the meantime, it seems cleaner to keep the formatted templates focused on structure rather than content. Structurally Turkish addresses are just a generic1, so this PR migrates them to that format (test modified accordingly, passes under the perl-Geo-Address-Formatter suite).

That ok on your end?