### PR TITLE
Regex escape chars need a double backslash for Python YAML parser

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -279,7 +279,7 @@ BR:
         {{{postcode}}}
         {{{country}}}
     postformat_replace:
-        - ["\b(\d{5})(\d{3})\b","$1-$2"]
+        - ["\\b(\\d{5})(\\d{3})\\b","$1-$2"]
 
 # Botswana
 BW:


### PR DESCRIPTION
Python's YAML parser errors when parsing the strings in Brazil's postformat_replace (regex escape characters need to be double backslashed). I've corrected the issue. The Perl tests, which cover the Brazil postal code case, still pass.