### PR TITLE
Double backslash in Guatemala postformat_replace

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -532,7 +532,7 @@ GT:
         {{{postcode}}}-{{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{state}}} {{/first}}
         {{{country}}}
     postformat_replace:
-        - [", (\d{5})- ",", $1-"]
+        - [", (\\d{5})- ",", $1-"]
         - [", -",", "]
 
 


### PR DESCRIPTION
Minor change, was breaking YAML parsing on the Python side