### PR TITLE
Adding state twice in Russian addresses

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -116,8 +116,8 @@ generic14: &generic14 |
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}
-        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
-        {{#first}} {{{state}}} || {{{state_district}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{state_district}}} {{/first}}
+        {{{state}}}
         {{{country}}}
 
 # postcode and comma before house number

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -80,14 +80,15 @@ generic10: &generic10 |
         {{{house}}}
         {{{road}}} {{{house_number}}}
         {{{suburb}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{state}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
         {{{state}}}
         {{{country}}}
         {{{postcode}}}
 
 generic11: &generic11 |
         {{{country}}}
-        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{state}}} {{/first}}
+        {{{state}}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
         {{{suburb}}} 
         {{{road}}}, {{{house_number}}}
         {{{house}}}
@@ -99,7 +100,7 @@ generic12: &generic12 |
         {{{house}}}
         {{{house_number}}}, {{{road}}}
         {{{suburb}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{state}}} {{/first}} - {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}} - {{{postcode}}}
         {{{state}}}
         {{{country}}}
 
@@ -115,7 +116,7 @@ generic14: &generic14 |
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}
-        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || || {{{state_district}}} || {{{state}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
         {{#first}} {{{state}}} || {{{state_district}}} {{/first}}
         {{{country}}}
 

--- a/testcases/countries/kg.yaml
+++ b/testcases/countries/kg.yaml
@@ -11,6 +11,6 @@ components:
    postcode: 720033
    road: Frunze Mikhail Street
    state: Astana
-expected: 'Kyrgyzstan, 720033 Бишкек, Frunze Mikhail Street, 473, Даамдан'
+expected: 'Kyrgyzstan, Astana, 720033 Бишкек, Frunze Mikhail Street, 473, Даамдан'
 
 

--- a/testcases/countries/kz.yaml
+++ b/testcases/countries/kz.yaml
@@ -11,4 +11,4 @@ components:
    postcode: 010000
    road: улица Конституции
    state: Astana
-expected: 'Kazakhstan, 010000 Astana, улица Конституции, 24, Хива'
+expected: 'Kazakhstan, Astana, 010000 Astana, улица Конституции, 24, Хива'


### PR DESCRIPTION
I've seen a few anomalies in the address parser data with Russian addresses (and a few other post-Soviet countries) where states can potentially be added twice if other fields like city are missing. This PR fixes countries using generic10, generic11 and generic14.