### PR TITLE
Language-specific variants for China, Hong Kong, Japan, and South Korea

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -691,10 +691,10 @@ FO:
 FR:
     address_template: *generic3
     replace:
-        - ["Polynésie française, Îles du Vent \(eaux territoriales\)","Polynésie française"]
-        - ["France, Mayotte \(eaux territoriales\)","Mayotte, France"]
-        - ["France, La Réunion \(eaux territoriales\)","La Réunion, France"]
-        - ["\(eaux territoriales\)",""]
+        - ["Polynésie française, Îles du Vent \\(eaux territoriales\\)","Polynésie française"]
+        - ["France, Mayotte \\(eaux territoriales\\)","Mayotte, France"]
+        - ["France, La Réunion \\(eaux territoriales\\)","La Réunion, France"]
+        - ["\\(eaux territoriales\\)",""]
 
 # Gabon
 GA:
@@ -1388,7 +1388,7 @@ PE:
 PF:
     address_template: *generic3
     replace:
-        - ["Polynésie française, Îles du Vent \(eaux territoriales\)","Polynésie française"]
+        - ["Polynésie française, Îles du Vent \\(eaux territoriales\\)","Polynésie française"]
 
 
 # Papau New Guinea

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -489,6 +489,7 @@ CL:
 CM: 
     address_template: *generic17
 
+# China
 CN:
     address_template: |
         {{{attention}}}
@@ -499,6 +500,30 @@ CN:
         {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} {{/first}} {{#first}} {{{state_code}}} || {{{state}}} {{/first}} {{{postcode}}} 
         {{{country}}}
 
+# China - English
+CN_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}} 
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{county}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} {{/first}} {{#first}} {{{state_code}}} || {{{state}}} {{/first}} {{{postcode}}} 
+        {{{country}}}
+
+# China - Chinese
+CN_zh:
+    address_template: |
+        {{{country}}}
+        {{{postcode}}} 
+        {{#first}} {{{state_code}}} || {{{state}}} {{/first}}
+        {{#first}} {{{state_district}}} || {{{county}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}} 
+        {{{house}}}
+        {{{attention}}}
 
 # Colombia
 CO:
@@ -790,6 +815,28 @@ HK:
         {{{state_district}}}
         {{{state}}}
 
+# Hong Kong - English
+HK_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}} 
+        {{{state_district}}}
+        {{{state}}}
+        {{{country}}}
+
+# Hong Kong - Chinese
+HK_zh:
+    address_template: |
+        {{{country}}}
+        {{{state}}}
+        {{{state_district}}}
+        {{{road}}}
+        {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+
+
 # Heard Island and McDonald Islands - same as Australia
 HM: 
     use_country: AU
@@ -903,6 +950,38 @@ JP:
         # fix the postcode to make it \d\d\d-\d\d\d\d
         - [" (\\d{3})(\\d{4})\n"," $1-$2\n"]
 
+
+
+# Japan - English
+JP_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}, {{#first}} {{{state}}} || {{{state_district}}} {{/first}} {{{postcode}}}
+        {{{country}}}
+    postformat_replace:
+        # fix the postcode to make it \d\d\d-\d\d\d\d
+        - [" (\\d{3})(\\d{4})\n"," $1-$2\n"]
+
+
+# Japan - Japanese
+JP_ja:
+    address_template: |
+        {{{country}}}
+        {{{postcode}}}
+        {{#first}} {{{state}}} || {{{state_district}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
+    postformat_replace:
+        # fix the postcode to make it \d\d\d-\d\d\d\d
+        - [" (\\d{3})(\\d{4})\n"," $1-$2\n"]
+
 # Kenya
 KE:
     address_template: |
@@ -962,6 +1041,28 @@ KR:
         {{{house_number}}} {{{road}}} 
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}, {{#first}} {{{state}}} {{/first}} {{{postcode}}} 
         {{{country}}}
+
+# South Korea - English
+KR_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}} 
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}, {{#first}} {{{state}}} {{/first}} {{{postcode}}} 
+        {{{country}}}
+
+# South Korea - Korean
+KR_ko:
+    address_template: |
+        {{{country}}}
+        {{#first}} {{{state}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}} 
+        {{{house}}}
+        {{{attention}}}
+        {{{postcode}}}
 
 # Kuwait
 KW:


### PR DESCRIPTION
Hey Ed,

For countries using the East Asian addressing system (China, Hong Kong, Japan, and South Korea), the format of the address varies depending on which language is being used.

I'd propose keeping a single format for the raw country key (to stay backward-compatible), then add language-specific format keys like "{country}_{language}", e.g. for China:

- CN_en
- CN_zh

For libpostal, that'll allow us to train the parser on Chinese, Japanese and Korean addresses in OSM. It could also be useful in geocoders that want to localize display addresses (in Hong Kong for instance there are typically "name:en" and "name:zh" tags available from OSM).

Thoughts?

./al