### PR TITLE
Quoting "NO" for Norwegian territories

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -428,7 +428,7 @@ BT:
 
 # Bouvet Island
 BV:
-    use_country: BV
+    use_country: "NO"
     change_country: Bouvet Island, Norway
 
 # Botswana
@@ -1579,7 +1579,7 @@ SI:
 
 # Svalbard and Jan Mayen - same as Norway
 SJ:
-    use_country: NO
+    use_country: "NO"
     change_country: Norway
 
 # Slovakia


### PR DESCRIPTION
Hey folks. This one might just affect the Python YAML parser but in places where Norway's country code is used, "NO" is treated as a boolean rather than a string.