### PR TITLE
Brazil - house number comes after street

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -405,7 +405,7 @@ BR:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}}
+        {{{road}}}, {{{house_number}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} {{/first}} - {{#first}} {{{state_code}}} || {{{state}}} {{/first}}
         {{{postcode}}}
         {{{country}}}


### PR DESCRIPTION
Just noticed this while looking through some of my training data: https://en.wikipedia.org/wiki/Address_(geography)#Brazil