### PR TITLE
Road/house number order in Hebrew and some Arabic addresses

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -967,7 +967,7 @@ JM:
 
 # Jordan
 JO:
-    address_template: *generic2
+    address_template: *generic1
 
 # Japan
 JP:

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -1167,7 +1167,7 @@ LY:
 
 # Morocco
 MA:
-    address_template: *generic1
+    address_template: *generic3
 
 # Monaco
 MC:

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -917,7 +917,7 @@ IE:
 
 # Israel
 IL: 
-    address_template: *generic3
+    address_template: *generic1
 
 # Isle of Man
 IM: 

--- a/testcases/countries/il.yaml
+++ b/testcases/countries/il.yaml
@@ -12,7 +12,7 @@ components:
         state: Tel Aviv District
         suburb: Montefiore
 expected:  |
-    29 Yizhak Sadeh
+    Yizhak Sadeh 29
     64739 Tel Aviv-Yafo
     Israel
 

--- a/testcases/countries/ps.yaml
+++ b/testcases/countries/ps.yaml
@@ -22,7 +22,7 @@ components:
     town: Ramallah
 expected: |
     Hostel in Ramallah
-    12 Al-Nuzha Street
+    Al-Nuzha Street 12
     700074 Ramallah
     Palestine
 ---
@@ -40,7 +40,7 @@ components:
     town: رام الله
 expected: |
     Hostel in Ramallah
-    12 شارع النزهة
+    شارع النزهة 12
     700074 رام الله
     فلسطين
 ---


### PR DESCRIPTION
Hey folks, just noticed this while looking through some addresses in Israel and Palestine.

For Arabic, Hebrew, and some other languages that are written right-to-left, something like Al-Wahda Street 21 is written like شارع الوحدة 21 (in Hebrew, Ben Gurion Street 21 would be:  רחוב בן גוריון 21). The memory representation of these strings is left-to-right but at display time most browsers, etc. implement the [Unicode bi-directional spec](http://unicode.org/reports/tr9/) and display them right-to-left.

So the correct address format for Israel and Palestine should be street name followed by house number, and the browser will take care of the rest. I was curious if that applied to transliterations/English translations and it looks like it does: https://en.wikipedia.org/wiki/Address_(geography)#Israel.

Checked other Arabic-speaking countries for similar issues, and made two updates to Jordan ([house number follows street name](http://www.upu.int/fileadmin/documentsFiles/activities/addressingUnit/jorEn.pdf)) and Morocco (which [uses the French style](http://www.upu.int/fileadmin/documentsFiles/activities/addressingUnit/marEn.pdf)).