### PR TITLE
Yaml requires some strings to be quoted

### DIFF
--- a/conf/country_codes.yaml
+++ b/conf/country_codes.yaml
@@ -167,7 +167,7 @@ NF: # Norfolk Island
 NG: # Nigeria 
 NI: # Nicaragua 
 NL: # Netherlands 
-NO: # Norway 
+"NO": # Norway 
 NP: # Nepal 
 NR: # Nauru 
 NU: # Niue 

--- a/conf/state_codes.yaml
+++ b/conf/state_codes.yaml
@@ -49,7 +49,7 @@ CA:
     NT: Northwest Territories
     NS: Nova Scotia
     NU: Nunavut
-    ON: Ontario
+    "ON": Ontario
     PE: Prince Edward Island
     QC: Quebec
     SK: Saskatchewan


### PR DESCRIPTION
According to http://yaml.org/type/bool.html, "NO" and "ON" may be interpreted as booleans when not quoted.