### PR TITLE
Ireland and Jamaica postcodes

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -972,7 +972,7 @@ JE:
 
 # Jamaica
 JM:
-    address_template: *generic16
+    address_template: *generic20
 
 # Jordan
 JO:

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -910,8 +910,17 @@ ID:
         {{{country}}}
 
 # Ireland
+# https://en.wikipedia.org/wiki/Postal_addresses_in_the_Republic_of_Ireland
 IE: 
-    address_template: *generic6
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
+        {{{county}}}
+        {{{postcode}}}
+        {{{country}}}
     replace:
         - [" City$",""]
 

--- a/testcases/countries/ie.yaml
+++ b/testcases/countries/ie.yaml
@@ -12,6 +12,7 @@ components:
     suburb: Claddagh
 expected:  |
     8-9 Mainguard Street
+    Claddagh
     Galway
     Ireland
 

--- a/testcases/countries/jm.yaml
+++ b/testcases/countries/jm.yaml
@@ -13,6 +13,7 @@ components:
 expected:  |
     Old Court House
     Constitution Street
+    Tawes Meadows
     Spanish Town
     Jamaica
 


### PR DESCRIPTION
Hey all,

This PR adds postal codes to Ireland ([Eirecodes](https://en.wikipedia.org/wiki/Postal_addresses_in_the_Republic_of_Ireland#Eircode)) and Jamaica ([Kingston postal zones](https://en.wikipedia.org/wiki/Kingston,_Jamaica#Postal_Service)), as well as suburbs/city_districts for those two countries.

Cheers,
Al