### PR TITLE
Postcode after city in Singapore

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -1588,7 +1588,7 @@ SE:
 
 # Singapore
 SG:
-    address_template: *generic3
+    address_template: *generic2
 
 # Saint Helena, Ascension and Tristan da Cunha - same as UK
 SH:


### PR DESCRIPTION
From a libpostal issue, it appears that for Singapore the format should be postcode after city: https://en.wikipedia.org/wiki/Address_(geography)#Singapore. This PR switches Singapore to the generic2 template.