### PR TITLE
Iran config (Farsi/English)

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -979,7 +979,8 @@ IR_en:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}, {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
         {{{road}}}
         {{{house_number}}}
         {{#first}} {{{province}}} || {{{state}}} {{/first}}

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -963,8 +963,40 @@ IQ:
         {{{country}}}
 
 # Iran
-IR: 
-    address_template: *generic17
+IR:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{#first}} {{{province}}} || {{{state}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+IR_en:
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}, {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{#first}} {{{province}}} || {{{state}}} {{/first}}
+        {{{postcode}}}
+        {{{country}}}
+
+IR_fa:
+    address_template: |
+        {{{country}}}
+        {{{postcode}}}
+        {{#first}} {{{state}}} || {{{province}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{{road}}}
+        {{{house_number}}}
+        {{{house}}}
+        {{{attention}}}
 
 # Iceland
 IS: 

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -990,7 +990,6 @@ IR_en:
 IR_fa:
     address_template: |
         {{{country}}}
-        {{{postcode}}}
         {{#first}} {{{state}}} || {{{province}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
@@ -998,6 +997,7 @@ IR_fa:
         {{{house_number}}}
         {{{house}}}
         {{{attention}}}
+        {{{postcode}}}
 
 # Iceland
 IS: 

--- a/testcases/countries/ir.yaml
+++ b/testcases/countries/ir.yaml
@@ -12,7 +12,8 @@ components:
             suburb: Ostad Moein
 expected:  |
     Azadi Tower
-    Tehran, Ostad Moein
+    Tehran
+    Ostad Moein
     Azadi Square
     1351956118
     Iran

--- a/testcases/countries/ir.yaml
+++ b/testcases/countries/ir.yaml
@@ -9,12 +9,10 @@ components:
             country_code: ir
             postcode: 1351956118
             road: Azadi Square
-            state: Tehran
             suburb: Ostad Moein
 expected:  |
     Azadi Tower
+    Tehran, Ostad Moein
     Azadi Square
-    Tehran
+    1351956118
     Iran
-
-


### PR DESCRIPTION
Hey all - from some discussion in https://github.com/openvenues/libpostal/issues/243, it seems that for Iran there needs to be:

1. An update to the English config (sources: [UPU](www.upu.int/fileadmin/documentsFiles/activities/addressingUnit/irnEn.pdf), [Wikipedia](https://en.wikipedia.org/wiki/Address_(geography)#Iran))
2. A fully-reversed format that should be used when the address is in Farsi (this is similar to the formats I'd previously added for countries like China, Japan, and South Korea where the language determines the address format)

Updated the tests accordingly and everything's passing.

Cheers!