### PR TITLE
fix: State codes for India

### DIFF
--- a/conf/state_codes.yaml
+++ b/conf/state_codes.yaml
@@ -785,6 +785,7 @@ IE:
     WH: Westmeath
     WW: Wicklow
     WX: Wexford
+IN:
     AN: Andaman and Nicobar Islands
     AP: Andhra Pradesh
     AR: Arunachal Pradesh


### PR DESCRIPTION
`IN` key was probably omitted by mistake.