### PR TITLE
Add a link to a Rust implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ There are open-source implementations in
   * [Javascript](https://github.com/fragaria/address-formatter)
   * [Perl](https://github.com/opencagedata/perl-Geo-Address-Formatter) - [on CPAN](https://metacpan.org/release/Geo-Address-Formatter)
   * [PHP](https://github.com/predicthq/address-formatter-php)
+  * [Rust](https://github.com/CanalTP/address-formatter-rs)
 
 We would love there to be other language implementations.
 If you write a processor, please let us know so we can list it here. 


### PR DESCRIPTION
Hi,

Thanks for the work with those configurations!

I've implemented the address formatting in Rust: https://github.com/CanalTP/address-formatter-rs

It is not yet completed, but there is a first shot at the implementation (I still have 8 failling tests, and do not handle abbreviation yet).

Thanks again for the great work!