### PR TITLE
IE: Remove 'The Municipal District of '

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -950,7 +950,7 @@ IE:
         {{{country}}}
     replace:
         - [" City$",""]
-        - ["The Municiple District of ",""]   
+        - ["The Municipal District of ",""]   
 
 # Israel
 IL: 

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -950,6 +950,7 @@ IE:
         {{{country}}}
     replace:
         - [" City$",""]
+        - ["The Municiple District of ",""]   
 
 # Israel
 IL: 


### PR DESCRIPTION
'The Municipal District of  ' is not used in Irish addresses