### PR TITLE
Removes postcode from Irish Addresses

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -946,7 +946,6 @@ IE:
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} {{/first}}
         {{{county}}}
-        {{{postcode}}}
         {{{country}}}
     replace:
         - [" City$",""]

--- a/testcases/countries/ie.yaml
+++ b/testcases/countries/ie.yaml
@@ -56,7 +56,6 @@ components:
     county: County Limerick
     county_code: LK
     locality: Farranshone Beg
-    postcode: V94 PD28
     road: Shelbourne Road
     road_reference: R464
     state: Munster
@@ -65,5 +64,4 @@ expected:  |
     Farranshone
     Limerick
     County Limerick
-    V94 PD28
     Ireland


### PR DESCRIPTION
Postcode (eircode) in Ireland is not appropriate as it is allocated
to an exact address and not to an area or cluster.
This can cause errors when selecting an area on a map and the eircode
for a nearby property is returned.

An example of this is the address 'Forth, Keeloges, County Wexford, Y35
CY80'. The eircode actually points to Knockeen Nursing Home, Knockeen,
Barntown, County Wexford.

For this reason I propose that the eircode/postcode is removed for Irish
addresses