### PR TITLE
Prefer city district over suburb for neighbourhood

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -982,7 +982,7 @@ IQ:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{#first}} {{{neighbourhood}}} || {{{city_district}}} || {{{suburb}}} {{/first}}
+        {{{house_number}}} {{#first}} {{{city_district}}} || {{{neighbourhood}}} || {{{suburb}}} {{/first}}
         {{{road}}}         
         {{#first}} {{{city}}} || {{{town}}} || {{{state}}} || {{{village}}} {{/first}}
         {{{postcode}}}


### PR DESCRIPTION
Solution to the query I raised here:
https://github.com/OpenCageData/address-formatting/issues/58

In the Iraqi address we use `city_district` as the neighbourhood instead of `suburb` so this should be represented in the aliases configuration.