### PR TITLE
Cleans up duplicate keys in state_codes

### DIFF
--- a/conf/state_codes.yaml
+++ b/conf/state_codes.yaml
@@ -565,7 +565,7 @@ CH:
       default: Zürich
       alt_en: Zurich      
       alt_fr: Zurich
-      alt_fr: Zurigo      
+      alt_it: Zurigo      
 CI:    
     AB: Abidjan
     BS: Bas-Sassandra
@@ -1251,60 +1251,30 @@ LT:
     AL:
       default: Alytaus apskritis
       alt_en: Alytus County
-    AL:
-      default: Alytaus apskritis
-      alt_en: Alytus County
-    KL:
-      default: Klaipėdos apskritis
-      alt_en: Klaipeda County
     KL:
       default: Klaipėdos apskritis
       alt_en: Klaipeda County
     KU:
       default: Kauno apskritis
       alt_en: Kaunas County
-    KU:
-      default: Kauno apskritis
-      alt_en: Kaunas County
-    MR:
-      default: Marijampolės apskritis
-      alt_en: Marijampole County
     MR:
       default: Marijampolės apskritis
       alt_en: Marijampole County
     PN:
       default: Panevėžio apskritis
       alt_en: Panevezys County
-    PN:
-      default: Panevėžio apskritis
-      alt_en: Panevezys County
-    SA:
-      default: Šiaulių apskritis
-      alt_en: Siauliai County
     SA:
       default: Šiaulių apskritis
       alt_en: Siauliai County
     TA:
       default: Tauragės apskritis
       alt_en: Taurage County
-    TA:
-      default: Tauragės apskritis
-      alt_en: Taurage County
-    TE:
-      default: Telšių apskritis
-      alt_en: Telsiai County
     TE:
       default: Telšių apskritis
       alt_en: Telsiai County
     UT:
       default: Utenos apskritis
       alt_en: Utena County
-    UT:
-      default: Utenos apskritis
-      alt_en: Utena County
-    VL:
-      default: Vilniaus apskritis
-      alt_en: Vilnius County
     VL:
       default: Vilniaus apskritis
       alt_en: Vilnius County


### PR DESCRIPTION
Closes #68 and also removes more duplicate keys that are invalid per the YAML specification.