### PR TITLE
Add quotes to multiple postcodes.

### DIFF
--- a/testcases/countries/de.yaml
+++ b/testcases/countries/de.yaml
@@ -182,7 +182,7 @@ components:
         country: Germany
         country_code: de
         county: Aschaffenburg
-        postcode: 63739,63741,63743
+        postcode: '63739,63741,63743'
         road: Haselmühlweg
         state: Free State of Bavaria
         state_district: Lower Franconia


### PR DESCRIPTION
A string of digits separated by comma without quotes can be evaluated as integer by some YAML parsing libraries (eg: [psych for ruby](https://github.com/ruby/psych/issues/273)):

```ruby
YAML.load("postcode: 63739,63741,63743")
 => {"postcode"=>637396374163743}
```

```ruby
YAML.load("postcode: '63739,63741,63743'")
 => {"postcode"=>"63739,63741,63743"}
```