### PR TITLE
Add go package to list of processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ There are open-source implementations in
   * [Ruby](https://github.com/mirubiri/address_composer)
   * [Rust](https://github.com/CanalTP/address-formatter-rs)
   * [Scala](https://github.com/ben-willis/address-formatter)
+  * [Go](https://github.com/timonmasberg/address-formatter)
 
 We would love more language implementations. The more people who use the templates, the more likely bugs will be reported. 
 If you write a processor, please submit a pull request adding it to the list. Thanks. 


### PR DESCRIPTION
I wrote a processor in go, you can check it out [here](https://github.com/timonmasberg/address-formatter). I will add abbreviations and extend the documentary later on. 

Contribution appreciated.