### PR TITLE
Add alias 'housenumber'

### DIFF
--- a/conf/components.yaml
+++ b/conf/components.yaml
@@ -2,6 +2,7 @@
 name: house_number
 aliases:
     - street_number
+    - housenumber
 ---
 name: house
 aliases:


### PR DESCRIPTION
I tried `address-formatting` using the JavaScript implementation for Photon API. Unfortunately, the house numbers could not be recognized, because the property from the  Photon response is spelled `housenumber` and not `house_number`. See Issue https://github.com/fragaria/address-formatter/issues/493 for details.

I could locally ensure that it works like expected for me, but I am not sure if it has unintended side effects. Please let me know if there is more test to be done or if there is more work needed in this pull request.

Thanks for providing this very useful repository. 

