### PR TITLE
Update Readme. Add link to Android library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Our goal with this repository is a series of (programming) language independent 
 
 There are open-source implementations in
 
+  * [Android library](https://github.com/woheller69/AndroidAddressFormatter)
   * [Elixir](https://github.com/dkuku/ex_address_formatting)
   * [Go](https://github.com/timonmasberg/address-formatter)
   * [Java](https://github.com/placemarkt/address-formatter-java)


### PR DESCRIPTION
The Java version (Placemarkt) did not work on Android, so I created an Android library. It is used in my LavSeeker app, which shows toilets listed in OpenStreetMap

 https://github.com/woheller69/lavatories