### PR TITLE
Add postcode to Ireland address (eircode)

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -989,6 +989,7 @@ IE:
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
         {{{county}}}
+        {{{postcode}}}
         {{{country}}}
     replace:
         - [" City$",""]


### PR DESCRIPTION
https://www.citizensinformation.ie/en/consumer/phone_internet_tv_and_postal_services/eircode.html#:~:text=The%20Eircode%20should%20be%20placed,mandatory%20to%20use%20the%20Eircode. The eircode is not mandatory. Code not tested. Cheers ;)

Address sample: 

Block C
Maynooth Business Campus
Maynooth
Kildare
W23 F854