### PR TITLE
Add postcode to Mauritius

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -1428,7 +1428,12 @@ MR:
 
 # Mauritius
 MU:
-    address_template: *generic18
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{house_number}}}, {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{state}}} {{/first}} {{{postcode}}}
+        {{{country}}}
 
 # Maldives
 MV:


### PR DESCRIPTION
Post codes have been introduced to Mauritius in 2014
https://en.wikipedia.org/wiki/Postal_codes_in_Mauritius
