### PR TITLE
Mauritius test case with postcode

### DIFF
--- a/testcases/countries/mu.yaml
+++ b/testcases/countries/mu.yaml
@@ -8,7 +8,6 @@ components:
         country_code: mu
         house_number: 1
         neighbourhood: Caudan Waterfront
-        postcode: 230
         road: Queen Elizabeth II Avenue
         state: Port Louis
 expected:  |
@@ -16,6 +15,19 @@ expected:  |
     1, Queen Elizabeth II Avenue
     Port Louis
     Mauritius
-
-
-
+---
+# example from https://en.wikipedia.org/wiki/Postal_codes_in_Mauritius
+description: example address with postcode
+components:
+        city: Lalmatie
+        country: Mauritius
+        country_code: mu
+        house_number: 21
+        neighbourhood: Mission Cross
+        postcode: 42602
+        road: Old Trafford Road
+expected: |
+        21, Old Trafford Road
+        Mission Cross
+        Lalmatie 42602
+        Mauritius


### PR DESCRIPTION
Removed post code 230 in original test. it seems like this is not a valid post code but rather a trick that Mauritians used before 2014 (https://yashvinblogs.com/2012/02/08/postal-code-zip-mauritius)