### PR TITLE
Afghanistan postal codes

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -263,7 +263,14 @@ AE:
 
 # Afghanistan
 AF:
-    address_template: *generic21
+    address_template: |
+        {{{attention}}}
+        {{{house}}}
+        {{{road}}} {{{house_number}}} 
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} 
+        {{{postcode}}}
+        {{{country}}}
 
 # Antigua and Barbuda
 AG:

--- a/testcases/countries/af.yaml
+++ b/testcases/countries/af.yaml
@@ -8,10 +8,12 @@ components:
         country_code: af
         road: Kandahar-Herat Highway
         state: Kandahar
+        postcode: 3803
 expected:  |
     Kandahar Institute of Health Sciences
     Kandahar-Herat Highway
     Kandahar
+    3803
     Afghanistan
 
 


### PR DESCRIPTION
Afghanistan introduced Postal Codes/ZIP codes in 2011
syntax source: https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/afgEn.pdf
