### PR TITLE
Italian addresses: no comma between street and house number

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -67,7 +67,7 @@ generic7: &generic7 |
 generic8: &generic8 |
         {{{attention}}}
         {{{house}}}
-        {{{road}}}, {{{house_number}}} 
+        {{{road}}} {{{house_number}}} 
         {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{county_code}}} || {{{county}}} {{/first}}
         {{{country}}}
 

--- a/testcases/countries/it.yaml
+++ b/testcases/countries/it.yaml
@@ -11,7 +11,7 @@ components:
     state: Apulia
     suburb: Montaltino
 expected:  |
-    Via Pisacane, 13
+    Via Pisacane 13
     76121 Barletta BT
     Italy
 ---


### PR DESCRIPTION
for https://github.com/OpenCageData/address-formatting/issues/98

@freyfogle please review