### PR TITLE
Remove trailing whitespace and fix some issues in templates

### DIFF
--- a/conf/components.yaml
+++ b/conf/components.yaml
@@ -27,7 +27,7 @@ aliases:
 name: place
 aliases:
     - farmland
-    - allotments    
+    - allotments
 ---
 name: hamlet
 aliases:
@@ -49,11 +49,11 @@ aliases:
     - commercial
     - industrial
     - houses
-    - subdistrict    
+    - subdistrict
     - subdivision
     - ward
 ---
-name: postal_city    
+name: postal_city
 ---
 name: city
 aliases:
@@ -64,7 +64,7 @@ name: municipality
 aliases:
     - local_administrative_area
     - subcounty
----    
+---
 name: county
 aliases:
     - county_code

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -1778,7 +1778,7 @@ SG:
         {{{attention}}}
         {{#first}} {{{house}}}, {{{quarter}}} || {{{house}}} {{/first}}
         {{{house_number}}} {{{road}}}, {{{residential}}}
-        {{#first}} {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{village}}} || {{{county}}} {{/first}} {{{postcode}}}
+        {{#first}} {{{country}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{village}}} || {{{county}}} {{/first}} {{{postcode}}}
         {{{country}}}
 
 # Saint Helena, Ascension and Tristan da Cunha - same as UK

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -1,4 +1,4 @@
-#n}}} 
+#n}}}
 # generic mappings, specific territories get mapped to these
 #
 # postcode before city
@@ -24,7 +24,7 @@ generic3: &generic3 |
         {{{house}}}
         {{{house_number}}} {{{road}}}
         {{{place}}}
-        {{{postcode}}} {{#first}} {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{city}}} || {{{municipality}}} || {{{state}}} {{/first}}        
+        {{{postcode}}} {{#first}} {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{city}}} || {{{municipality}}} || {{{state}}} {{/first}}
         {{{country}}}
 
 # postcode after state
@@ -41,7 +41,7 @@ generic5: &generic5 |
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{#first}} {{{state_district}}} || {{{state}}} {{/first}}
         {{{country}}}
 
@@ -50,24 +50,24 @@ generic6: &generic6 |
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
         {{{county}}}
-        {{{state}}}         
+        {{{state}}}
         {{{country}}}
 
 # city, postcode
 generic7: &generic7 |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}}{{/first}}, {{{postcode}}} 
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}}{{/first}}, {{{postcode}}}
         {{{country}}}
 
 # postcode and county
 generic8: &generic8 |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
+        {{{road}}} {{{house_number}}}
         {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{county_code}}} || {{{county}}} {{/first}}
         {{{country}}}
 
@@ -137,15 +137,15 @@ generic16: &generic16 |
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}}
         {{{country}}}
 
 # no postcode, no state, just city
 generic17: &generic17 |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}} 
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}}
         {{{country}}}
 
 # no postcode, just city comma after house number
@@ -153,7 +153,7 @@ generic18: &generic18 |
         {{{attention}}}
         {{{house}}}
         {{{house_number}}}, {{{road}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{state}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{state}}} {{/first}}
         {{{country}}}
 
 # suburb and postcode after city
@@ -162,25 +162,25 @@ generic19: &generic19 |
         {{{house}}}
         {{{road}}} {{{house_number}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
         {{{country}}}
 
 # suburb and postcode after city
 generic20: &generic20 |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
         {{{country}}}
 
 # suburb and city, no postcode
 generic21: &generic21 |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
+        {{{road}}} {{{house_number}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
         {{{country}}}
 
 # comma after housenumber, postcode before city
@@ -215,7 +215,7 @@ fallback2: &fallback2 |
         {{{attention}}}
         {{{house}}}
         {{{road}}} {{{house_number}}}
-        {{{place}}}        
+        {{{place}}}
         {{#first}} {{{suburb}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{municipality}}} || {{{county}}} || {{{island}}} || {{{state_district}}} {{/first}}, {{#first}} {{{state}}} || {{{state_code}}} {{/first}}
         {{{country}}}
@@ -224,7 +224,7 @@ fallback3: &fallback3 |
         {{{attention}}}
         {{{house}}}
         {{{road}}} {{{house_number}}}
-        {{{place}}}        
+        {{{place}}}
         {{#first}} {{{suburb}}} || {{{island}}} {{/first}}
         {{#first}} {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
         {{#first}} {{{town}}} || {{{city}}}{{/first}}
@@ -236,7 +236,7 @@ fallback4: &fallback4 |
         {{{attention}}}
         {{{house}}}
         {{{road}}} {{{house_number}}}
-        {{{place}}}        
+        {{{place}}}
         {{{suburb}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} {{/first}}
         {{#first}} {{{state}}} || {{{county}}} {{/first}}
@@ -245,7 +245,7 @@ fallback4: &fallback4 |
 default:
     address_template: *generic1
     fallback_template: *fallback1
-    
+
 # country / territory specific mappings
 # please keep in alpha order by country code
 #
@@ -262,7 +262,7 @@ AE:
         {{{house}}}
         {{{house_number}}} {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{#first}} {{{state_district}}} || {{{state}}} {{/first}}
         {{{country}}}
 
@@ -279,7 +279,7 @@ AI:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
+        {{{road}}} {{{house_number}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{postcode}}} {{{country}}}
 
@@ -288,7 +288,7 @@ AL:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
+        {{{road}}} {{{house_number}}}
         {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{city_district}}} || {{{municipality}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{country}}}
     postformat_replace:
@@ -300,8 +300,8 @@ AM:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
-        {{{postcode}}} 
+        {{{house_number}}} {{{road}}}
+        {{{postcode}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{#first}} {{{state_district}}} || {{{state}}} {{/first}}
         {{{country}}}
@@ -319,7 +319,7 @@ AQ:
         {{#first}} {{{country}}} || {{{continent}}} {{/first}}
 
 # Argentina
-AR: 
+AR:
     address_template: *generic9
     replace:
         - ["^Autonomous City of ",""]
@@ -328,21 +328,21 @@ AR:
         - ["\n(\\w\\d{4})(\\w{3}) ","\n$1 $2 "]
 
 # American Samoa
-AS: 
+AS:
     use_country: US
     change_country: United States of America
     add_component: state=American Samoa
 
 # Austria
-AT: 
+AT:
     address_template: *generic1
 
 # Australia
-AU: 
+AU:
     address_template: *generic13
 
 # Aruba
-AW: 
+AW:
     address_template: *generic17
 
 # Åland Islands, part of Finnland
@@ -405,7 +405,7 @@ BJ:
 # Saint Barthélemy - same as FR
 BL:
     use_country: FR
-    change_country: Saint-Barthélemy, France     
+    change_country: Saint-Barthélemy, France
 
 # Bermuda
 BM:
@@ -416,9 +416,9 @@ BN:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}}, {{{road}}} 
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} 
-        {{#first}} {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}} {{{postcode}}} 
+        {{{house_number}}}, {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{#first}} {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}} {{{postcode}}}
         {{{country}}}
 
 
@@ -451,9 +451,9 @@ BS:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} 
-        {{{county}}} 
+        {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
+        {{{county}}}
         {{{country}}}
 
 # Bhutan
@@ -463,7 +463,7 @@ BT:
         {{{house}}}
         {{{road}}} {{{house_number}}}, {{{house}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}}
         {{{country}}}
 
 # Bouvet Island
@@ -476,9 +476,9 @@ BW:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
+        {{{road}}} {{{house_number}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{country}}}
 
 # Belarus
@@ -490,7 +490,7 @@ BZ:
     address_template: *generic16
 
 # Canada - https://en.wikipedia.org/wiki/Address#Canada
-CA: 
+CA:
     address_template: |
         {{{attention}}}
         {{{house}}}
@@ -508,7 +508,7 @@ CA:
         - [" ([A-Za-z]{2}) ([A-Za-z]\\d[A-Za-z])(\\d[A-Za-z]\\d)\n"," $1 $2 $3\n"]
 
 #Canada - English
-CA_en: 
+CA_en:
     address_template: |
         {{{attention}}}
         {{{house}}}
@@ -564,20 +564,20 @@ CH:
         {{{country}}}
     replace:
         - ["Verwaltungskreis",""]
-        - ["Verwaltungsregion",""]        
+        - ["Verwaltungsregion",""]
         - [" administrative district",""]
         - [" administrative region",""]
 
 # Côte d'Ivoire
-CI: 
+CI:
     address_template: *generic16
 
 # Cook Islands
-CK: 
+CK:
     address_template: *generic16
 
 # Chile - https://en.wikipedia.org/wiki/Address#Chile
-CL: 
+CL:
     address_template: |
         {{{attention}}}
         {{{house}}}
@@ -585,9 +585,9 @@ CL:
         {{{postcode}}} {{#first}} {{{postal_city}}} || {{{town}}} || {{{city}}} || {{{village}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
         {{{region}}}
         {{{country}}}
-    
+
 # Cameroon
-CM: 
+CM:
     address_template: *generic17
 
 # China
@@ -597,7 +597,7 @@ CN:
         {{#first}} {{{state_code}}} || {{{state}}} || {{{state_district}}} || {{{region}}}{{/first}}
         {{{county}}}
         {{#first}}{{{city}}} || {{{town}}} || {{{municipality}}}|| {{{village}}}|| {{{hamlet}}}{{/first}}
-        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}        
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
         {{{road}}} {{{house_number}}}
         {{{house}}}
         {{{attention}}}
@@ -621,11 +621,11 @@ CN_zh:
         {{#first}} {{{state_code}}} || {{{state}}} || {{{state_district}}} || {{{region}}}{{/first}}
         {{{county}}}
         {{#first}}{{{city}}} || {{{town}}} || {{{municipality}}}|| {{{village}}}|| {{{hamlet}}}{{/first}}
-        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}        
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
         {{{road}}} {{{house_number}}}
         {{{house}}}
         {{{attention}}}
-        
+
 # Colombia
 CO:
     address_template: |
@@ -636,7 +636,7 @@ CO:
         {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{state_code}}} || {{{state}}} {{/first}}
         {{{country}}}
     postformat_replace:
-        - ["Localidad "," "]    
+        - ["Localidad "," "]
         - ["Bogota, Bogota","Bogota"]
         - ["Bogota, Bogotá Distrito Capital","Bogota"]
         - ["Bogotá, Bogotá Distrito Capital","Bogotá"]
@@ -662,24 +662,24 @@ CV:
         - ["\n(\\d{4}) ([^,]*)\n","\n$1-$2\n"]
 
 # Curaçao
-CW: 
+CW:
     address_template: *generic17
 
 # Christmas Island - same as Australia
-CX: 
+CX:
     use_country: AU
     add_component: state=Christmas Island
     change_country: Australia
 
 # Cyprus
-CY: 
+CY:
     address_template: *generic1
 
 # Czech Republic
-CZ: 
+CZ:
     address_template: *generic1
     postformat_replace:
-        # fix the postcode to make it \d\d\d \d\d 
+        # fix the postcode to make it \d\d\d \d\d
         - ["\n(\\d{3})(\\d{2}) ","\n$1 $2 "]
 
 # Germany
@@ -693,13 +693,13 @@ DE:
         {{#first}} {{{town}}} || {{{city}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} || {{{county}}} {{/first}}
         {{#first}} {{{state}}} || {{{state_district}}} {{/first}}
         {{{country}}}
-    
+
     replace:
         - ["^Stadtteil ",""]
         - ["^Stadtbezirk (\\d+)",""]
-        - ["^Ortsbeirat (\\d+) :",""]        
+        - ["^Ortsbeirat (\\d+) :",""]
         - ["^Gemeinde ",""]
-        - ["^Gemeindeverwaltungsverband ",""]        
+        - ["^Gemeindeverwaltungsverband ",""]
         - ["^Landkreis ",""]
         - ["^Kreis ",""]
         - ["^Grenze ",""]
@@ -734,10 +734,10 @@ DO:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
+        {{{road}}} {{{house_number}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{{state}}} 
-        {{{postcode}}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{{state}}}
+        {{{postcode}}}
         {{{country}}}
     postformat_replace:
         - [", Distrito Nacional",", DN"]
@@ -763,8 +763,8 @@ EG:
         {{{house}}}
         {{{house_number}}} {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
-        {{{postcode}}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{postcode}}}
         {{{country}}}
 
 # Estonia
@@ -794,26 +794,26 @@ ET:
     address_template: *generic1
 
 # Finnland
-FI: 
+FI:
     address_template: *generic1
 
 # Fiji
-FJ: 
+FJ:
     address_template: *generic16
 
 # Falkland Islands
-FK: 
+FK:
     use_country: GB
     change_country: Falkland Islands, United Kingdom
 
 # Federated States of Micronesia
-FM: 
+FM:
     use_country: US
     change_country: United States of America
     add_component: state=Micronesia
 
-# Faroe Islands 
-FO: 
+# Faroe Islands
+FO:
     address_template: *generic1
     postformat_replace:
         - ["Territorial waters of Faroe Islands","Faroe Islands"]
@@ -830,14 +830,14 @@ FR:
         - ["\\(eaux territoriales\\)",""]
         - ["state= \\(France\\)$",""]
         - ["Paris (\\d+)(\\w+) Arrondissement$","Paris"]
-        
+
 
 # Gabon
 GA:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}}
         {{{country}}}
@@ -853,7 +853,7 @@ GB:
         - ["^Greater London","London"]
         - ["^London Borough of ",""]
         - ["Royal Borough of ",""]
-        - ["County Borough of ",""]        
+        - ["County Borough of ",""]
     postformat_replace:
         - ["London, London","London"]
         - ["London, Greater London","London"]
@@ -873,7 +873,7 @@ GE:
 # French Guiana - same as FR
 GF:
     use_country: FR
-    change_country: France     
+    change_country: France
 
 # Guernsey - same format as UK, but not part of UK
 GG:
@@ -885,7 +885,7 @@ GH:
     address_template: *generic16
 
 # Gibraltar
-GI: 
+GI:
     address_template: *generic16
 
 # Greenland
@@ -903,10 +903,10 @@ GN:
 # Guadeloupe - same as FR
 GP:
     use_country: FR
-    change_country: Guadeloupe, France     
+    change_country: Guadeloupe, France
 
 # Equatorial Guinea
-GQ: 
+GQ:
     address_template: *generic17
 
 # Greece
@@ -938,7 +938,7 @@ GT:
         - ["\n -","\n"]
 
 # Guam
-GU: 
+GU:
     use_country: US
     change_country: United States of America
     add_component: state=Guam
@@ -956,7 +956,7 @@ HK:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{{state_district}}}
         {{#first}} {{{state}}} || {{{country}}} {{/first}}
 
@@ -965,7 +965,7 @@ HK_en:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{{state_district}}}
         {{{state}}}
         {{{country}}}
@@ -983,17 +983,17 @@ HK_zh:
 
 
 # Heard Island and McDonald Islands - same as Australia
-HM: 
+HM:
     use_country: AU
     change_country: Australia
     add_component: state=Heard Island and McDonald Islands
 
 # Honduras
-HN: 
+HN:
     address_template: *generic1
 
 # Croatia
-HR: 
+HR:
     address_template: *generic1
 
 # Haiti
@@ -1007,8 +1007,8 @@ HU:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
-        {{{road}}} {{{house_number}}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{road}}} {{{house_number}}}
         {{{postcode}}}
         {{{country}}}
 
@@ -1026,7 +1026,7 @@ ID:
 
 # Ireland
 # https://en.wikipedia.org/wiki/Postal_addresses_in_the_Republic_of_Ireland
-IE: 
+IE:
     address_template: |
         {{{attention}}}
         {{{house}}}
@@ -1041,21 +1041,21 @@ IE:
         - ["The Municipal District of ",""]
         - ["The Metropolitan District of ",""]
         - ["Municipal District",""]
-        - ["Electoral Division",""]        
+        - ["Electoral Division",""]
     postformat_replace:
         - ["Dublin\nCounty Dublin","Dublin"]
         - ["Dublin\nLeinster","Dublin"]
         - ["Galway\nCounty Galway","Galway"]
-        - ["Kilkenny\nCounty Kilkenny","Kilkenny"]        
+        - ["Kilkenny\nCounty Kilkenny","Kilkenny"]
         - ["Limerick\nCounty Limerick","Limerick"]
         - ["Tipperary\nCounty Tipperary","Tipperary"]
         # fix eircode formatting
         #- ["\n(\\d{4})(\\w{2}) ","\n$1 $2 "]
-        - ["\n(([AC-FHKNPRTV-Y][0-9]{2}|D6W))[ -]?([0-9AC-FHKNPRTV-Y]{4})", "\n$1 $3"] 
-        
+        - ["\n(([AC-FHKNPRTV-Y][0-9]{2}|D6W))[ -]?([0-9AC-FHKNPRTV-Y]{4})", "\n$1 $3"]
+
 
 # Israel
-IL: 
+IL:
     address_template: *generic1
 
 # Isle of Man
@@ -1073,12 +1073,12 @@ IO:
     change_country: British Indian Ocean Territory, United Kingdom
 
 # Iraq
-IQ: 
+IQ:
     address_template: |
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{#first}} {{{city_district}}} || {{{neighbourhood}}} || {{{suburb}}} {{/first}}
-        {{{road}}}         
+        {{{road}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{state}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{postcode}}}
         {{{country}}}
@@ -1123,11 +1123,11 @@ IR_fa:
         {{{postcode}}}
 
 # Iceland
-IS: 
+IS:
     address_template: *generic1
 
 # Italy
-IT: 
+IT:
     address_template: *generic8
     replace:
         - ["Città metropolitana di ",""]
@@ -1214,7 +1214,7 @@ KH:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
         {{{country}}}
@@ -1234,20 +1234,20 @@ KM:
         {{{country}}}
 
 # Saint Kitts and Nevis
-KN: 
+KN:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{state}}} || {{{island}}} {{/first}}
         {{{country}}}
 
 # Democratic People's Republic of Korea / North Korea
-KP: 
+KP:
     address_template: *generic21
 
 # Republic of Korea / South Korea -- https://en.wikipedia.org/wiki/Address#South_Korea
-KR: 
+KR:
     address_template: |
         {{{country}}}
         {{{state}}}
@@ -1260,8 +1260,8 @@ KR_en:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
-        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{/first}} {{{postcode}}} 
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{/first}} {{{postcode}}}
         {{{state}}}
         {{{country}}}
 
@@ -1269,7 +1269,7 @@ KR_en:
 KR_ko:
     address_template: |
         {{{country}}}
-        {{#first}} {{{state}}} {{/first}} 
+        {{{state}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{{road}}} {{{house_number}}}
         {{{attention}}}
         {{{postcode}}}
@@ -1281,7 +1281,7 @@ KW:
         {{{house}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
 
-        {{{road}}} 
+        {{{road}}}
         {{{house_number}}} {{{house}}}
         {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{country}}}
@@ -1295,11 +1295,11 @@ KZ:
     address_template: *generic11
 
 # Laos
-LA: 
+LA:
     address_template: *generic22
 
 # Lebanon
-LB: 
+LB:
     address_template: *generic2
     postformat_replace:
         # fix the postcode to make it nonbreaking space
@@ -1310,7 +1310,7 @@ LC:
     address_template: *generic17
 
 # Liechtenstein, same as Switzerland
-LI: 
+LI:
     use_country: CH
 
 # Sri Lanka
@@ -1365,7 +1365,7 @@ ME:
 # Collectivité de Saint-Martin
 MF:
     use_country: FR
-    change_country: France     
+    change_country: France
 
 # Marshall Islands
 MH:
@@ -1377,9 +1377,9 @@ MG:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
+        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{country}}}
 
 # North Macedonia
@@ -1392,11 +1392,11 @@ ML:
 
 # Myanmar (Burma)
 MM:
-    address_template: | 
+    address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}, {{{postcode}}} 
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}, {{{postcode}}}
         {{{country}}}
 
 
@@ -1405,12 +1405,12 @@ MN:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{city_district}}} 
+        {{{city_district}}}
         {{#first}} {{{suburb}}} || {{{neighbourhood}}} {{/first}}
-        {{{road}}} 
-        {{{house_number}}} 
+        {{{road}}}
+        {{{house_number}}}
         {{{postcode}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{country}}}
 
 # Macau
@@ -1437,7 +1437,7 @@ MO_zh:
         {{{country}}}
         {{#first}} {{{suburb}}} || {{{village}}} || {{{hamlet}}} || {{{state_district}}} {{/first}}
         {{{road}}}
-        {{{house_number}}}    
+        {{{house_number}}}
         {{{house}}}
         {{{attention}}}
 
@@ -1456,15 +1456,15 @@ MT:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
-        {{#first}} {{{city}}} || {{{town}}} || {{{suburb}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{suburb}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{postcode}}}
         {{{country}}}
 
 # Martinique - overseas territory of France (FR)
 MQ:
     use_country: FR
-    change_country: Martinique, France     
+    change_country: Martinique, France
 
 # Mauritania
 MR:
@@ -1515,32 +1515,32 @@ MZ:
     fallback_template: *fallback4
 
 # Namibia
-NA: 
+NA:
     address_template: *generic2
 
 # New Caledonia, special collectivity of France
 NC:
     use_country: FR
-    change_country: Nouvelle-Calédonie, France     
+    change_country: Nouvelle-Calédonie, France
 
 # Niger
-NE: 
+NE:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} 
+        {{{house_number}}}
         {{{road}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{country}}}
 
 # Norfolk Island - same as Australia
-NF: 
+NF:
     use_country: AU
     add_component: state=Norfolk Island
     change_country: Australia
 
 # Nigeria
-NG: 
+NG:
     address_template: |
         {{{attention}}}
         {{{house}}}
@@ -1568,13 +1568,13 @@ NL:
     address_template: *generic1
 
 # Nepal
-NP: 
+NP:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
+        {{{road}}} {{{house_number}}}
         {{#first}} {{{suburb}}} || {{{neighbourhood}}} || {{{city}}} {{/first}}
-        {{#first}} {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}} {{{postcode}}} 
+        {{#first}} {{{municipality}}} || {{{county}}} || {{{state_district}}} || {{{state}}} {{/first}} {{{postcode}}}
         {{{country}}}
 
 # Nauru
@@ -1596,7 +1596,7 @@ OM:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{{postcode}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{state}}}
@@ -1624,7 +1624,7 @@ PE:
 # French Polynesia - same as FR
 PF:
     use_country: FR
-    change_country: Polynésie française, France     
+    change_country: Polynésie française, France
     replace:
         - ["Polynésie française, Îles du Vent \\(eaux territoriales\\)","Polynésie française"]
 
@@ -1634,8 +1634,8 @@ PG:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}} {{{state}}} 
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}} {{{state}}}
         {{{country}}}
 
 # Philippines - https://en.wikipedia.org/wiki/Address#Philippines
@@ -1645,8 +1645,8 @@ PH:
         {{{house}}}
         {{{house_number}}} {{{road}}}, {{#first}} {{{suburb}}}, || {{{city_district}}}, || {{{neighbourhood}}}, {{/first}} {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{suburb}}} || {{{state_district}}} {{/first}}
         {{{postcode}}} {{#first}} {{{municipality}}} {{{region}}} {{{state}}} {{/first}}
-        {{{country}}} 
-        
+        {{{country}}}
+
 # Pakistan
 PK:
     address_template: |
@@ -1654,28 +1654,28 @@ PK:
         {{{house}}}
         {{{house_number}}} {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}}
         {{{country}}}
 
 # Poland
 PL:
     address_template: *generic1
     postformat_replace:
-        # fix the postcode to make it \d\d-\d\d\d 
+        # fix the postcode to make it \d\d-\d\d\d
         - ["\n(\\d{2})(\\w{3}) ","\n$1-$2 "]
 
 
 # Saint Pierre and Miquelon - same as FR
 PM:
     use_country: FR
-    change_country: Saint-Pierre-et-Miquelon, France     
+    change_country: Saint-Pierre-et-Miquelon, France
 
 # Pitcairn Islands
 PN:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{island}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{island}}} {{/first}}
         {{{country}}}
 
 # Puerto Rico, same as USA
@@ -1694,14 +1694,14 @@ PT:
     postformat_replace:
         # fix the postcode to add - after numbers
         - ["\n(\\d{4})(\\d{3}) ","\n$1-$2 "]
-    
+
 
 # Palau
-PW: 
+PW:
     address_template: *generic1
 
 # Parguay
-PY: 
+PY:
     address_template: *generic1
 
 # Qatar
@@ -1711,11 +1711,11 @@ QA:
 # Réunion - same as FR
 RE:
     use_country: FR
-    change_country: La Réunion, France     
+    change_country: La Réunion, France
 
 
 # Romania
-RO: 
+RO:
     address_template: *generic1
 
 # Serbia
@@ -1748,25 +1748,25 @@ SA:
         {{{country}}}
 
 # Solomon Islands
-SB: 
+SB:
     address_template: *generic17
 
 # Seychelles
-SC: 
+SC:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{island}}} {{/first}} 
+        {{{house_number}}} {{{road}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{island}}} {{/first}}
         {{{island}}}
         {{{country}}}
 
 # Sudan
-SD: 
+SD:
     address_template: *generic1
 
 # Sweden
-SE: 
+SE:
     address_template: *generic1
     postformat_replace:
         # fix the postcode to make it \d\d\d \d\d
@@ -1778,8 +1778,8 @@ SG:
         {{{attention}}}
         {{#first}} {{{house}}}, {{{quarter}}} || {{{house}}} {{/first}}
         {{{house_number}}} {{{road}}}, {{{residential}}}
-        {{#first}} {{{country}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{village}}} || {{{county}}} {{/first}} {{{postcode}}}
-        {{#first}} {{{country}}} {{/first}}
+        {{#first}} {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{village}}} || {{{county}}} {{/first}} {{{postcode}}}
+        {{{country}}}
 
 # Saint Helena, Ascension and Tristan da Cunha - same as UK
 SH:
@@ -1787,7 +1787,7 @@ SH:
     change_country: $state, United Kingdom
 
 # Slovenia
-SI: 
+SI:
     address_template: *generic1
 
 # Svalbard and Jan Mayen - same as Norway
@@ -1796,7 +1796,7 @@ SJ:
     change_country: Norway
 
 # Slovakia
-SK: 
+SK:
     address_template: |
         {{{attention}}}
         {{{house}}}
@@ -1806,7 +1806,7 @@ SK:
     replace:
         - ["^District of ",""]
         - ["^Region of ",""]
-    postformat_replace:        
+    postformat_replace:
         # fix the postcode to make it \d\d\d \d\d
         - ["\n(\\d{3})(\\d{2}) ","\n$1 $2 "]
 
@@ -1815,19 +1815,19 @@ SL:
     address_template: *generic16
 
 # San Marino - same as IT
-SM: 
+SM:
     use_country: IT
 
 # Senegal
 SN:
     address_template: *generic3
     replace:
-        - ["^Commune de ",""]    
+        - ["^Commune de ",""]
         - ["^Arrondissement de ",""]
         - ["^Département de ",""]
 
 # Somalia
-SO: 
+SO:
     address_template: *generic21
 
 # Suriname
@@ -1835,7 +1835,7 @@ SR:
     address_template: *generic21
 
 # South Sudan
-SS: 
+SS:
     address_template: *generic17
 
 # São Tomé and Príncipe
@@ -1843,41 +1843,41 @@ ST:
     address_template: *generic17
 
 # El Salvador
-SV: 
+SV:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}} 
-        {{{postcode}}} - {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
-        {{{state}}} 
+        {{{road}}} {{{house_number}}}
+        {{{postcode}}} - {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{state}}}
         {{{country}}}
     postformat_replace:
         - ["\n- ","\n "]
 
 # Sint Maarten
-SX: 
+SX:
     address_template: *generic17
 
 # Syria
-SY: 
+SY:
     address_template: |
         {{{attention}}}
         {{{house}}}
         {{{road}}}, {{{house_number}}}
         {{#first}} {{{village}}} || {{{hamlet}}} || {{{city_district}}} || {{{neighbourhood}}} || {{{suburb}}} {{/first}}
         {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} || {{{state}}} {{/first}}
-        
+
         {{{country}}}
 
 
 # Swaziland
-SZ: 
+SZ:
     address_template: |
         {{{attention}}}
         {{{house}}}
         {{{road}}} {{{house_number}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
-        {{{postcode}}} 
+        {{{postcode}}}
         {{{country}}}
 
 # Turks and Caicos Islands
@@ -1888,17 +1888,17 @@ TC:
         {{{house_number}}} {{{road}}}
         {{quarter}}
         {{#first}} {{{village}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} {{/first}}
-        {{{island}}}        
-        {{#first}} {{{country}}} {{/first}}
+        {{{island}}}
+        {{{country}}}
 
 # Chad
-TD: 
+TD:
     address_template: *generic21
 
 # French Southern and Antarctic Lands
 TF:
     use_country: FR
-    change_country: Terres australes et antarctiques françaises, France     
+    change_country: Terres australes et antarctiques françaises, France
 
 # Togo
 TG:
@@ -1910,9 +1910,9 @@ TH:
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{#first}} {{{village}}} || {{{hamlet}}} {{/first}}
-        {{{road}}} 
+        {{{road}}}
         {{#first}} {{{neighbourhood}}} || {{{city}}} || {{{town}}} {{/first}}, {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
-        {{{state}}} {{{postcode}}} 
+        {{{state}}} {{{postcode}}}
         {{{country}}}
 
 # Tajikistan
@@ -1925,11 +1925,11 @@ TK:
     change_country: Tokelau, New Zealand
 
 # Timor-Leste/East Timor
-TL: 
+TL:
     address_template: *generic17
 
 # Turkmenistan
-TM: 
+TM:
     address_template: *generic22
 
 # Tunisia
@@ -1937,11 +1937,11 @@ TN:
     address_template: *generic3
 
 # Tonga
-TO: 
+TO:
     address_template: *generic16
 
 # Turkey
-TR: 
+TR:
     address_template: *generic1
 
 # Trinidad and Tobago
@@ -1955,7 +1955,7 @@ TT:
         {{{country}}}
 
 # Tuvalu
-TV: 
+TV:
     address_template: |
         {{{attention}}}
         {{{house}}}
@@ -1965,11 +1965,11 @@ TV:
         {{{country}}}
 
 # Taiwan -- https://en.wikipedia.org/wiki/Address#Taiwan
-TW: 
+TW:
     address_template: |
         {{{country}}}
         {{{postcode}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{city_district}}} || {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
         {{{house}}}
         {{{attention}}}
 
@@ -1977,7 +1977,7 @@ TW_en:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}}, {{{road}}} 
+        {{{house_number}}}, {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
         {{{country}}}
 
@@ -1985,7 +1985,7 @@ TW_zh:
     address_template: |
         {{{country}}}
         {{{postcode}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{city_district}}} || {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
         {{{house}}}
         {{{attention}}}
 
@@ -2005,7 +2005,7 @@ UA:
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{municipality}}} {{/first}}
         {{#first}} {{{region}}} || {{{state}}} {{/first}}
-        {{{postcode}}} 
+        {{{postcode}}}
         {{{country}}}
 
 # Uganda
@@ -2020,7 +2020,7 @@ UM:
     add_component: state=US Minor Outlying Islands
 
 # USA
-US: 
+US:
     address_template: *generic4
     fallback_template: *fallback2
     replace:
@@ -2039,21 +2039,21 @@ UZ:
         {{{attention}}}
         {{{house}}}
         {{{road}}} {{{house_number}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} 
-        {{#first}} {{{state}}} || {{{state_district}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{#first}} {{{state}}} || {{{state_district}}} {{/first}}
         {{{country}}}
         {{{postcode}}}
 
 # Uruguay
-UY: 
+UY:
     address_template: *generic1
 
 # Vatican City - same as IT
-VA: 
+VA:
     use_country: IT
 
 # Saint Vincent and the Grenadines
-VC: 
+VC:
     address_template: *generic17
 
 # Venezuela
@@ -2070,12 +2070,12 @@ VG:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{house_number}}} {{{road}}} 
+        {{{house_number}}} {{{road}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{{island}}}
         {{{country}}}, {{{postcode}}}
 
 # US Virgin Islands, same as USA
-VI: 
+VI:
     use_country: US
     change_country: United States of America
     add_component: state=US Virgin Islands
@@ -2086,7 +2086,7 @@ VN:
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}
-        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} 
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state_district}}} {{/first}}
         {{{state}}} {{{postcode}}}
         {{{country}}}
@@ -2098,7 +2098,7 @@ VU:
 # Wallis and Futuna, same as France
 WF:
     use_country: FR
-    change_country: Wallis-et-Futuna, France     
+    change_country: Wallis-et-Futuna, France
 
 # Samoa
 WS:
@@ -2111,16 +2111,16 @@ YE:
 # Mayotte - same as FR
 YT:
     use_country: FR
-    change_country: Mayotte, France     
+    change_country: Mayotte, France
 
 # South Africa
-ZA: 
+ZA:
     address_template: |
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{state_district}}} {{/first}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} 
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}}
         {{{postcode}}}
         {{{country}}}
 

--- a/conf/state_codes.yaml
+++ b/conf/state_codes.yaml
@@ -159,7 +159,7 @@ AR:
     B: Buenos Aires
     C:
       default: Ciudad Autónoma de Buenos Aires
-      alt_en: Autonomous City of Buenos Aires      
+      alt_en: Autonomous City of Buenos Aires
     D: San Luis
     E:
       default: Entre Ríos
@@ -344,7 +344,7 @@ BE:
       alt_fr: Anvers
     VBR:
       default: Vlaams Brabant
-      alt_de: Flämisch-Brabant      
+      alt_de: Flämisch-Brabant
       alt_en: Flemish Brabant
       alt_fr: Brabant flamand
     VLI:
@@ -356,7 +356,7 @@ BE:
       alt_fr: Flandre orientale
     VWV:
       default: West-Vlaanderen
-      alt_de: Westflandern      
+      alt_de: Westflandern
       alt_en: West Flanders
       alt_fr: Flandre-Occidentale
     WBR:
@@ -629,7 +629,7 @@ CH:
       default: Appenzell Innerrhoden
       alt_fr: Appenzell Rhodes-Intérieures
       alt_it: Appenzello Interno
-    AR: 
+    AR:
       default: Appenzell Ausserrhoden
       alt_fr: Appenzell Rhodes-Extérieures
       alt_it: Appenzello Esterno
@@ -637,7 +637,7 @@ CH:
       default: Bern
       alt_fr: Berne
       alt_it: Berna
-    BL: 
+    BL:
       default: Basel-Landschaft
       alt_fr: Bâle-Campagne
       alt_it: Basilea Campagna
@@ -645,12 +645,12 @@ CH:
       default: Basel-Stadt
       alt_en: Basel-City
       alt_fr: Bâle-Ville
-      alt_it: Basilea Città   
-    FR: 
+      alt_it: Basilea Città
+    FR:
       default: Fribourg
       alt_de: Freiburg
       alt_it: Friburgo
-    GE: 
+    GE:
       default: Geneva
       alt_de: Genf
       alt_fr: Genève
@@ -659,7 +659,7 @@ CH:
       default: Glarus
       alt_fr: Glaris
       alt_it: Glarona
-    GR: 
+    GR:
       default: Graubünden
       alt_en: Grisons
       alt_fr: Grisons
@@ -667,21 +667,21 @@ CH:
     JU:
       default: Jura
       alt_it: Giura
-    LU: 
+    LU:
       default: Luzern
       alt_fr: Lucerne
       alt_it: Lucerna
-    NE: 
+    NE:
       default: Neuchâtel
       alt_de: Neuenburg
-    NW: 
+    NW:
       default: Nidwalden
       alt_fr: Nidwald
       alt_it: Nidvaldo
     OW:
       default: Obwalden
       alt_fr: Obwald
-      alt_it: Obvaldo   
+      alt_it: Obvaldo
     SG:
       default: Sankt Gallen
       alt_fr: Saint-Gall
@@ -689,7 +689,7 @@ CH:
     SH:
       default: Schaffhausen
       alt_fr: Schaffhouse
-      alt_it: Sciaffusa   
+      alt_it: Sciaffusa
     SO:
       default: Solothurn
       alt_fr: Soleure
@@ -720,10 +720,10 @@ CH:
       alt_it: Zugo
     ZH:
       default: Zürich
-      alt_en: Zurich      
+      alt_en: Zurich
       alt_fr: Zurich
-      alt_it: Zurigo      
-CI:    
+      alt_it: Zurigo
+CI:
     AB: Abidjan
     BS: Bas-Sassandra
     CM: Comoé
@@ -737,7 +737,7 @@ CI:
     VB: Vallée du Bandama
     WR: Woroba
     YM: Yamoussoukro
-    ZZ: Zanzan    
+    ZZ: Zanzan
 CL:
     AI: Aisén del General Carlos Ibañez del Campo
     AN: Antofagasta
@@ -856,7 +856,7 @@ DE:
     SL: Saarland
     SN:
       default: Sachsen
-      alt_en: Saxony      
+      alt_en: Saxony
     ST:
       default: Sachsen-Anhalt
       alt_en: Saxony-Anhalt
@@ -929,14 +929,14 @@ ER:
 ES:
     AN :
       default: Andalucía
-      alt_en:  Andalusia      
-    AR : 
+      alt_en:  Andalusia
+    AR :
       default: Aragón
-      alt_en: Aragon    
+      alt_en: Aragon
     AS : Asturias
     CB : Cantabria
     CE : Ceuta
-    CL : 
+    CL :
       default: Castilla y León
       alt_en: Castile and León
     CM :
@@ -944,7 +944,7 @@ ES:
       alt_en: Castile-La Mancha
     CN :
       default: Canarias
-      alt_en: Canary Islands   
+      alt_en: Canary Islands
     CT :
       default: Cataluña
       alt_ca: Catalunya
@@ -953,7 +953,7 @@ ES:
     GA : Galicia
     IB :
       default: Islas Baleares
-      alt_en: Balearic Islands    
+      alt_en: Balearic Islands
     MC :
       default: Región de Murcia
       alt_en: Region of Murcia
@@ -987,7 +987,7 @@ FR:
     BFC: Bourgogne-Franche-Comté
     BRE:
       default: Bretagne
-      alt_en: Brittany 
+      alt_en: Brittany
     CVL: Centre-Val de Loire
     COR:
       default: Corse
@@ -1253,13 +1253,13 @@ ID:
       alt_en: West Java
     JI:
       default: Jawa Timur
-      alt_en: East Java    
+      alt_en: East Java
     JK:
       default: Daerah Khusus Ibukota Jakarta
       alt_en: Jakarta Special Capital Region
     JT:
       default: Jawa Tengah
-      alt_en: Central Java    
+      alt_en: Central Java
     KB:
       default: Kalimantan Barat
       alt_en: West Kalimantan
@@ -1298,7 +1298,7 @@ ID:
       alt_en: West Sumatra
     SG:
       default: Sulawesi Tenggara
-      alt_en: Southeast Sulawesi      
+      alt_en: Southeast Sulawesi
     SN:
       default: Sulawesi Selatan
       alt_en: South Sulawesi
@@ -1358,7 +1358,7 @@ IN:
     TR: Tripura
     UP: Uttar Pradesh
     UT: Uttarakhand
-    WB: West Bengal    
+    WB: West Bengal
 IT:
     ABR: Abruzzo
     BAS: Basilicata
@@ -1617,7 +1617,7 @@ LB:
     NA:
       default: محافظة النبطية
       alt_en: Nabatiya Governorate
-      alt_fr: Gouvernorat de Nabatiyeh      
+      alt_fr: Gouvernorat de Nabatiyeh
 LR:
     BG: Bong
     BM: Bomi
@@ -2196,7 +2196,7 @@ PL:
       alt_en: Lublin Voivodeship
     "08":
       default: województwo lubuskie
-      alt_en: Lubusz Voivodeship      
+      alt_en: Lubusz Voivodeship
     "10":
       default: województwo łódzkie
       alt_en: Łódź Voivodeship
@@ -2205,13 +2205,13 @@ PL:
       alt_en: Lesser Poland Voivodeship
     "14":
       default: województwo mazowieckie
-      alt_en: Masovian Voivodeship      
+      alt_en: Masovian Voivodeship
     "16":
       default: województwo opolskie
       alt_en: Opole Voivodeship
     "18":
       default: województwo podkarpackie
-      alt_en: Subcarpathian Voivodeship      
+      alt_en: Subcarpathian Voivodeship
     "20":
       default: województwo podlaskie
       alt_en: Podlaskie Voivodeship
@@ -2223,7 +2223,7 @@ PL:
       alt_en: Silesian Voivodeship
     "26":
       default: województwo świętokrzyskie
-      alt_en: Świętokrzyskie Voivodeship      
+      alt_en: Świętokrzyskie Voivodeship
     "28":
       default: województwo warmińsko-mazurskie
       alt_en: Warmian-Masurian Voivodeship
@@ -2418,7 +2418,7 @@ SK:
     ZI:
       default: Žilinský kraj
       alt_en: Region of Žilina
-SL:    
+SL:
     E: Eastern
     N: Northern
     S: Southern


### PR DESCRIPTION
Mostly removes trailing whitespace. Also unwrapped single-choice `{{#first}}`s.

Two important changes hidden in big diffs: Singapore's template was broken, it added country twice. And in Taiwan's, `city_district` was mentioned twice.