### PR TITLE
Update link to Rust implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ There are open-source implementations in
   * [PHP](https://github.com/predicthq/address-formatter-php)
   * [Python](https://github.com/pudo/addressformatting/tree/master)
   * [Ruby](https://github.com/mirubiri/address_composer)
-  * [Rust](https://github.com/CanalTP/address-formatter-rs)
+  * [Rust (No Longer Maintained)](https://github.com/antoine-de/address-formatter-rs)
   * [Scala](https://github.com/ben-willis/address-formatter)
 
 We would love more language implementations. The more people who use the templates, the more likely bugs will be reported. 


### PR DESCRIPTION
I am unsure if @antoine-de is still working on this given the original link leading to a 404 and this personal repo: https://github.com/antoine-de/address-formatter-rs having last been committed to 5 years ago