### PR TITLE
typo_in_worldwide

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -695,7 +695,7 @@ DE:
         {{#first}} {{{road}}} || {{{place}}} || {{{hamlet}}} {{/first}} {{{house_number}}}
         {{{postcode}}} {{#first}} {{{village}}} {{{postal_city}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
         {{{archipelago}}}
-        {{{country}}}    
+        {{{country}}}
     fallback_template: |
         {{{attention}}}
         {{{house}}}
@@ -1272,7 +1272,7 @@ KR_en:
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}
-        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{/first}} {{{postcode}}}
+        {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{{postcode}}}
         {{{state}}}
         {{{country}}}
 
@@ -2129,8 +2129,7 @@ XK:
         {{{house_number}}}, {{{road}}}
         {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{state}}} {{/first}} {{{postcode}}}
         {{{country}}}
-    
-    
+
 # Yemen
 YE:
     address_template: *generic18


### PR DESCRIPTION
I have an [elixir implementation](https://github.com/dkuku/ex_address_formatting), I did it a long time ago and now I tried to update it but I had problems. It turned out that there is duplicated a  `{{/first}} {{/first}}` and my parser is crashing on that.