### PR TITLE
Fix Iran country code

### DIFF
--- a/conf/country_codes.yaml
+++ b/conf/country_codes.yaml
@@ -108,7 +108,7 @@ IM: # Isle of Man
 IN: # India
 IO: # British Indian Ocean Territory
 IQ: # Iraq
-IR: # Iraq
+IR: # Iran
 IS: # Iceland
 IT: # Italy
 JE: # Jersey


### PR DESCRIPTION
Change comment from `IR` country code back from Iraq to Iran