### PR TITLE
remove html escapes for generic23

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -194,9 +194,9 @@ generic22: &generic22 |
 # postcode on own line
 generic23: &generic23 |
         {{{attention}}}
-        {{house}}
+        {{{house}}}
         {{{house_number}}} {{{road}}}
-        {{quarter}}
+        {{{quarter}}}
         {{#first}} {{{village}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} {{/first}}
         {{{postcode}}}
         {{#first}} {{{country}}} || {{{state}}} {{/first}}


### PR DESCRIPTION
It seems like a mistake to html-escape these fields.

E.g.

```
{
  house: "St. Judes & St. Pauls C of E (Va) Primary School",
  house_number: "10",
  road: "Kingsbury Road".
  city: "London",
  postcode: "N1 4AZ",
}
```
becomes
```
St. Judes &amp; St. Pauls C of E (Va) Primary School
10 Kingsbury Road
London
N1 4AZ
```