### PR TITLE
Philippines - use only one region

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -1658,7 +1658,7 @@ PH:
         {{{attention}}}
         {{{house}}}
         {{{house_number}}} {{{road}}}, {{#first}}{{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}}{{/first}}, {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} || {{{suburb}}} || {{{state_district}}} {{/first}}
-        {{{postcode}}} {{#first}} {{{municipality}}} {{{region}}} {{{state}}} {{/first}}
+        {{{postcode}}} {{#first}} {{{municipality}}} || {{{region}}} || {{{state}}} || {{/first}}
         {{{country}}}
 
 # Pakistan

--- a/testcases/countries/ph.yaml
+++ b/testcases/countries/ph.yaml
@@ -62,4 +62,21 @@ expected:  |
     121 Epifanio Delos Santos Ave., Wack-wack Greenhills, Mandaluyong
     1550 Metro Manila
     Philippines
-
+---
+# https://nominatim.openstreetmap.org/ui/details.html?osmtype=N&osmid=11556052391&class=amenity
+description: address - ignore additional region
+components:
+    road: Gerona - Pura Road
+    village: Poblacion 1
+    postcode: 2312
+    municipality: Pura
+    province: Tarlac
+    region: Central Luzon
+    country: Philippines
+    country_code: PH
+    attention: PYS Pharmacy
+expected:  |
+    PYS Pharmacy
+    Gerona - Pura Road, Poblacion 1
+    2312 Pura
+    Philippines


### PR DESCRIPTION
I checked the formats and found, this `first` block without any `||`. So I thought, either the first block is unnecessary, or the `||` are missing. The linked format page looks more like the `||` are missing, so I fixed it. But of course feel free to remove instead the `first` block. 