### PR TITLE
Concise Colombian postformat replace rules

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -640,12 +640,7 @@ CO:
         {{{country}}}
     postformat_replace:
         - ["Localidad "," "]
-        - ["Bogotá, Bogotá","Bogotá"]                
-        - ["Bogota, Bogota","Bogota"]
-        - ["Bogota, Bogotá Distrito Capital","Bogota"]
-        - ["Bogotá, Bogotá Distrito Capital","Bogotá"]
-        - ["Bogotá, Distrito Capital","Bogotá"]
-        - ["Bogota, Capital District","Bogota"]        
+        - ["(Bogot[áa]), (Bogot[áa]|Bogot[áa] Distrito Capital|Distrito Capital|Capital District)","$1"]     
 
 # Costa Rica
 CR:


### PR DESCRIPTION
I saw the [latest update](https://github.com/OpenCageData/address-formatting/commit/0db8d14ce30394cc0cd9b625b6c49a82f2180c5f) from the Colombian postformat replace rules and thought, that it could be more concise and even cover some more Bogota/Bogotá versions.