### PR TITLE
Fix component separation for (South) Korean addresses

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -1265,7 +1265,7 @@ KR:
     address_template: |
         {{{country}}}
         {{{state}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
         {{{attention}}}
         {{{postcode}}}
 
@@ -1284,7 +1284,7 @@ KR_ko:
     address_template: |
         {{{country}}}
         {{{state}}}
-        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}}, {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}}, {{{road}}} {{{house_number}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{village}}} || {{{hamlet}}} {{/first}} {{#first}} {{{suburb}}} || {{{city_district}}} || {{{neighbourhood}}} {{/first}} {{{road}}} {{{house_number}}}
         {{{attention}}}
         {{{postcode}}}
 

--- a/testcases/countries/kr.yaml
+++ b/testcases/countries/kr.yaml
@@ -13,7 +13,7 @@ components:
         village: Seocho-dong
 expected:  |
     South Korea
-    Seoul, 서초2동 (Seocho2-dong), Seocho-daero 74-gil
+    Seoul 서초2동 (Seocho2-dong) Seocho-daero 74-gil
     Haeundae Grand Hotel
     135-934
 ---


### PR DESCRIPTION
Commas are not typically used as a separator for Korean addresses (even when written on a single line; the components are self-describing due to suffixes).

I am not sure what the difference between the `KR` and the language specific templates is _supposed_ to be (same for others), but it looks like it's mirroring the Korean language address in Korea template so I've updated that too.

Apologies in advance if CI fails; I couldn't get the script to run (definitely a problem with my local env; I have written like 12 lines of Perl 20+ years ago), but I think I fixed the tests properly.