### PR TITLE
Update AL format

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -289,7 +289,8 @@ AL:
         {{{attention}}}
         {{{house}}}
         {{{road}}} {{{house_number}}}
-        {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{city_district}}} || {{{municipality}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
+        {{{postcode}}}
+        {{#first}} {{{city}}} || {{{town}}} || {{{city_district}}} || {{{municipality}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{country}}}
 
 # Armenia

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -291,9 +291,6 @@ AL:
         {{{road}}} {{{house_number}}}
         {{{postcode}}} {{#first}} {{{city}}} || {{{town}}} || {{{city_district}}} || {{{municipality}}} || {{{state_district}}} || {{{village}}} || {{{hamlet}}} {{/first}}
         {{{country}}}
-    postformat_replace:
-        # fix the postcode to add - after numbers
-        - ["\n(\\d{4}) ([^,]*)\n","\n$1-$2\n"]
 
 # Armenia
 AM:

--- a/testcases/countries/al.yaml
+++ b/testcases/countries/al.yaml
@@ -12,7 +12,8 @@ components:
 expected:  |
     Raiffeisen Bank
     Papa Gjon Pali II
-    1001-Tiranë
+    1001
+    Tiranë
     Albania
 ---
 description: Kindergarten in Tiranë, 41.32462,19.83047


### PR DESCRIPTION
It looks like Albanian's postal standard does not include a requirement to add a dash following the postcode. It also looks like the postcode should be on a separate line.

Sources:
* [UPU](https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/albEn.pdf)
  * postcode on a separate line, locality on separate line
* [Albania's ministry of the interior](https://www.osce.org/files/f/documents/e/4/37397.pdf)
  * page 3 item 3, translated to English `"The names representing the elements such as village/town/municipal unit (for Tirana), commune/municipality, and postal code shall be written on a separate line, separated from one another by a comma “,” or semicolon “;”."`