### PR TITLE
Improve Singapore Address Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ _Please note: the list is simple all officially assigned [ISO 3166-1 alpha-2 cod
 
 ### File format
 
-The files are in [YAML](http://yaml.org/) format. The templates are written in [Mustache](http://mustache.github.io/). Both formats are human readable, strict, solve escaping and support comments. YAML allows references (called "ankers") to avoid copy&paste, Mustache allows sub-templates (called "partials").
+The files are in [YAML](http://yaml.org/) format. The templates are written in [Mustache](http://mustache.github.io/) with a minor variation: the `{#first}` sections will take the first alternative for which a variable could be interpolated. Both formats are human readable, strict, solve escaping and support comments. YAML allows references (called "ankers") to avoid copy&paste, Mustache allows sub-templates (called "partials").
 
 ### How to add your country/territory
 
@@ -101,14 +101,15 @@ The files are in [YAML](http://yaml.org/) format. The templates are written in [
 
 2. edit `conf/countries/worldwide.yaml`
   * Possibly your country/territory uses an existing generic format as
-    defined at the top of the file. If so, great, just map you
+    defined at the top of the file. If so, great! Just map your
     country_code to the generic template. You may still want to add
     clean up code (see the entry for `DE` as an example).
-  * If not you need to define a new generic rule set
-      * possibly you will need to define new state/region mappings in `conf/state_codes.yaml`
+  * If not, you need to define a new rule set (may or may not be generic)
+    * You may also need to define new state/region mappings in `conf/state_codes.yaml`
 
-3. to test you will now need to process the .yaml test via a processer
+3. to test you will now need to process the .yaml test via a processor
    (see above) and ensure the input leads to the desired output.
+   We also run these checks automatically against pull requests to ensure against regressions.
 
 If in doubt, please get in touch by submitting an issue. 
 

--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -1805,7 +1805,6 @@ SG:
         {{{house}}}, {{{quarter}}}
         {{{house_number}}} {{{road}}}, {{{residential}}}
         {{#first}} {{{country}}} || {{{town}}} || {{{city}}} || {{{municipality}}} || {{{hamlet}}} || {{{village}}} || {{{county}}} {{/first}} {{{postcode}}}
-        {{{country}}}
 
 # Saint Helena, Ascension and Tristan da Cunha - same as UK
 SH:

--- a/testcases/countries/sg.yaml
+++ b/testcases/countries/sg.yaml
@@ -23,7 +23,6 @@ components:
 expected:  |
     16 Sandilands Road
     Singapore 546080
-    Singapore
 ---
 description: no city, 1.30585,103.78158
 components:
@@ -38,7 +37,6 @@ components:
 expected:  |
     26 Dover Crescent, Dover Gardens
     Singapore 130026
-    Singapore
 ---
 description: wrong city, 1.30585,103.78158
 components:
@@ -54,6 +52,3 @@ components:
 expected:  |
     26 Dover Crescent, Dover Gardens
     Singapore 130026
-    Singapore
-
-


### PR DESCRIPTION
The Singaporean address format is described in this Mail Quality Guide from Singapore Post: https://www.singpost.com/sites/default/files/2022-10/Mail%20Quality%20Guide%20v201106.pdf.

I know that this template collection is not *specifically* concerned with generating perfect postal addresses, but it seems clear that duplicating the country isn't expected. In a postal setting, the final line should always be just "Singapore" and the postal code.

The other fallbacks seem a bit suspect to be honest, but I'm sure someone is using them so I've made the smallest possible change and removed the duplicate country.