### PR TITLE
Add comma between street name and house number for Brazil addresses

### DIFF
--- a/conf/countries/worldwide.yaml
+++ b/conf/countries/worldwide.yaml
@@ -439,7 +439,7 @@ BR:
     address_template: |
         {{{attention}}}
         {{{house}}}
-        {{{road}}} {{{house_number}}}{{#first}}, {{{quarter}}}{{/first}}
+        {{{road}}}, {{{house_number}}}{{#first}}, {{{quarter}}}{{/first}}
         {{#first}} {{{suburb}}} || {{{city_district}}} || {{{village}}} || {{{hamlet}}}{{/first}}
         {{#first}} {{{city}}} || {{{town}}} || {{{state_district}}} {{/first}} - {{#first}} {{{state_code}}} || {{{state}}} {{/first}}
         {{{postcode}}}

--- a/testcases/countries/br.yaml
+++ b/testcases/countries/br.yaml
@@ -53,7 +53,7 @@ components:
     suburb: Catete
 expected:  |
     Condomínio Condomínio René Magritte
-    Rua Silveira Martins 68
+    Rua Silveira Martins, 68
     Catete
     Rio de Janeiro - RJ
     22221-000
@@ -89,7 +89,7 @@ components:
     country_code: br
     country: Brazil
 expected:  |
-    Av. dos Holandeses 9, Quadra 33
+    Av. dos Holandeses, 9, Quadra 33
     Calhau
     São Luís - MA
     65071-380


### PR DESCRIPTION
In Brazil, addresses are typically written with a comma between the street name and the house number.

According to Universal Postal Union, it is the most correct way: https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/braEn.pdf